### PR TITLE
chore: remove build from github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,3 @@ jobs:
         run: |
           pnpm lint
           pnpx prettier --check .
-
-      - name: Build
-        run: pnpm build


### PR DESCRIPTION
- removes build of app from github actions - vercel status reflects if build failed or not